### PR TITLE
feat: add the option for other in process of behaviour and problem

### DIFF
--- a/src/components/ResourceEditor.tsx
+++ b/src/components/ResourceEditor.tsx
@@ -176,6 +176,7 @@ export const ResourceEditor: React.FC<ResourceEditorProps> = ({
   const processOptions = [
     { value: "requirements-elicitation", label: "Requirements Elicitation" },
     { value: "game", label: "Game" },
+    { value: "other", label: "Other" },
   ];
 
   // Inicializar datos
@@ -391,27 +392,44 @@ export const ResourceEditor: React.FC<ResourceEditorProps> = ({
 
   const renderProcessCheckboxes = () => (
     <div className="space-y-2">
-      {processOptions.map(({ value, label }) => (
-        <label className="flex items-center" key={value}>
-          <input
-            type="checkbox"
-            checked={visualData.process?.includes(value) || false}
-            onChange={(e) => {
-              const newProcess = visualData.process || [];
-              if (e.target.checked) {
-                handleVisualChange("process", [...newProcess, value]);
-              } else {
-                handleVisualChange(
-                  "process",
-                  newProcess.filter((p: string) => p !== value),
-                );
-              }
-            }}
-            className="mr-2"
-          />
-          {label}
-        </label>
-      ))}
+      {processOptions.map(({ value, label }) => {
+        const currentProcess: string[] = visualData.process || [];
+        const isChecked = currentProcess.includes(value);
+        const hasOther = currentProcess.includes("other");
+        const disabled = !isChecked && (
+          (value === "other" && currentProcess.length > 0) ||
+          (value !== "other" && hasOther)
+        );
+        return (
+          <label
+            className={`flex items-center ${disabled ? "opacity-40 cursor-not-allowed" : ""}`}
+            key={value}
+          >
+            <input
+              type="checkbox"
+              disabled={disabled}
+              checked={isChecked}
+              onChange={(e) => {
+                if (e.target.checked) {
+                  // "other" es exclusivo; el resto se pueden combinar
+                  if (value === "other") {
+                    handleVisualChange("process", ["other"]);
+                  } else {
+                    handleVisualChange("process", [...currentProcess, value]);
+                  }
+                } else {
+                  handleVisualChange(
+                    "process",
+                    currentProcess.filter((p: string) => p !== value),
+                  );
+                }
+              }}
+              className="mr-2"
+            />
+            {label}
+          </label>
+        );
+      })}
     </div>
   );
 

--- a/src/lib/leia.ts
+++ b/src/lib/leia.ts
@@ -63,6 +63,19 @@ export function checkConstraints(leia: Leia) {
   }
 }
 
+export function checkProcessOthers(leia: Leia) {
+  const processes = [
+    leia.behaviour?.spec?.process,
+    leia.problem?.spec?.process,
+  ];
+
+  for (const process of processes) {
+    if (Array.isArray(process) && process.includes('other') && process.length > 1) {
+      throw new Error("When 'other' is selected in process, it must be the only value.");
+    }
+  }
+}
+
 export function resolveExtensions(leia: Leia) {
   const extensions = leia.problem?.spec?.extends;
   if (!extensions) return leia;
@@ -134,6 +147,7 @@ export function generateLeia(persona: any, behaviour: any, problem: any) {
   const entities = { persona: structuredClone(persona), behaviour: structuredClone(behaviour), problem: structuredClone(problem) };
 
   checkConstraints(entities);
+  checkProcessOthers(entities);
   const extendedEntities = resolveExtensions(entities);
   const overriddenEntities = resolveOverrides(extendedEntities);
   const replacedEntities = resolvePlaceholders(overriddenEntities);

--- a/src/screens/CreateLeia.tsx
+++ b/src/screens/CreateLeia.tsx
@@ -101,10 +101,10 @@ export const CreateLeia: React.FC = () => {
 
   // Estados para filtros de process
   const [problemProcess, setProblemProcess] = useState<
-    "all" | "requirements-elicitation" | "game"
+    "all" | "requirements-elicitation" | "game" | "other"
   >("all");
   const [behaviourProcess, setBehaviourProcess] = useState<
-    "all" | "requirements-elicitation" | "game"
+    "all" | "requirements-elicitation" | "game" | "other"
   >("all");
 
   // Estado para controlar la visibilidad/publicación de la LEIA
@@ -236,7 +236,7 @@ export const CreateLeia: React.FC = () => {
 
   const loadProblems = async (
     visibility: "all" | "public" | "private" = "all",
-    process: "all" | "requirements-elicitation" | "game" = "all",
+    process: "all" | "requirements-elicitation" | "game" | "other" = "all",
   ) => {
     try {
       const params: Record<string, string> = { visibility };
@@ -254,7 +254,7 @@ export const CreateLeia: React.FC = () => {
 
   const loadBehaviours = async (
     visibility: "all" | "public" | "private" = "all",
-    process: "all" | "requirements-elicitation" | "game" = "all",
+    process: "all" | "requirements-elicitation" | "game" | "other" = "all",
   ) => {
     try {
       const params: Record<string, string> = { visibility, process };
@@ -310,14 +310,14 @@ export const CreateLeia: React.FC = () => {
 
   // Funciones para manejar cambios de process
   const handleProblemProcessChange = (
-    process: "all" | "requirements-elicitation" | "game",
+    process: "all" | "requirements-elicitation" | "game" | "other",
   ) => {
     setProblemProcess(process);
     loadProblems(problemVisibility, process); // Solo recargar problems
   };
 
   const handleBehaviourProcessChange = (
-    process: "all" | "requirements-elicitation" | "game",
+    process: "all" | "requirements-elicitation" | "game" | "other",
   ) => {
     setBehaviourProcess(process);
     loadBehaviours(behaviourVisibility, process); // Solo recargar behaviours
@@ -346,8 +346,8 @@ export const CreateLeia: React.FC = () => {
 
   // Componente para selector de process
   const ProcessSelector: React.FC<{
-    value: "all" | "requirements-elicitation" | "game";
-    onChange: (value: "all" | "requirements-elicitation" | "game") => void;
+    value: "all" | "requirements-elicitation" | "game" | "other";
+    onChange: (value: "all" | "requirements-elicitation" | "game" | "other") => void;
   }> = ({ value, onChange }) => (
     <div className="flex flex-col items-center">
       <label className="text-xs text-gray-600 mb-1">Process</label>
@@ -355,7 +355,7 @@ export const CreateLeia: React.FC = () => {
         value={value}
         onChange={(e) =>
           onChange(
-            e.target.value as "all" | "requirements-elicitation" | "game",
+            e.target.value as "all" | "requirements-elicitation" | "game" | "other",
           )
         }
         className="px-2 py-1 text-sm border border-gray-300 rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all duration-200 ease-in-out w-auto min-w-[60px] max-w-[140px]"
@@ -363,6 +363,7 @@ export const CreateLeia: React.FC = () => {
         <option value="all">All</option>
         <option value="requirements-elicitation">Req. Elicitation</option>
         <option value="game">Game</option>
+        <option value="other">Other</option>
       </select>
     </div>
   );


### PR DESCRIPTION
Actualizado el componente ResourceEditor.tsx, refactorizando la función renderProcessCheckboxes para que, si se selecciona el proceso "other", sea el único proceso seleccionable. Asimismo, si ya hay otro proceso seleccionado, "other" no puede marcarse.
Añadido un validador en el Source Editor para asegurar también que no se pueda escribir "other" junto con otro proceso.
En la pantalla CreateLeia, en el primer paso de selección de problem, behaviour y persona, se ha añadido la opción de filtrar por el proceso "other".
