### PR TITLE
Feature/ask user to add newly created leia to an activity

### DIFF
--- a/src/components/AddLeiaToAnActivity.tsx
+++ b/src/components/AddLeiaToAnActivity.tsx
@@ -5,6 +5,8 @@ import type { Experiment } from "../models/Experiment";
 import type { Leia } from "../models/Leia";
 import api from "../lib/axios";
 
+type Activity = Experiment;
+
 type SelectOption = {
   value: string;
   label: string;
@@ -26,59 +28,59 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
   onClose,
   onSuccess,
 }) => {
-  const [draftExperiments, setDraftExperiments] = useState<Experiment[] | null>(
+  const [draftActivities, setDraftActivities] = useState<Activity[] | null>(
     null,
   );
-  const [loadingDraftExperiments, setLoadingDraftExperiments] = useState(false);
-  const [errorLoadingDraftExperiments, setErrorLoadingDraftExperiments] =
+  const [loadingDraftActivities, setLoadingDraftActivities] = useState(false);
+  const [errorLoadingDraftActivities, setErrorLoadingDraftActivities] =
     useState<string | null>(null);
-  const [selectedDraftExperimentId, setSelectedDraftExperimentId] = useState<
+  const [selectedDraftActivityId, setSelectedDraftActivityId] = useState<
     string | null
   >(null);
-  const [creatingNewExperiment, setCreatingNewExperiment] = useState(false);
-  const [addingLeiaToExperiment, setAddingLeiaToExperiment] = useState(false);
+  const [creatingNewActivity, setCreatingNewActivity] = useState(false);
+  const [addingLeiaToActivity, setAddingLeiaToActivity] = useState(false);
   const [pendingNewName, setPendingNewName] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
-  const loadDraftExperiments = async () => {
-    setErrorLoadingDraftExperiments(null);
+  const loadDraftActivities = async () => {
+    setErrorLoadingDraftActivities(null);
     try {
-      setLoadingDraftExperiments(true);
+      setLoadingDraftActivities(true);
       const response = await api.get<Experiment[]>("/api/v1/experiments/user/me", {
         params: { visibility: "private" },
       });
-      setDraftExperiments(response.data || []);
+      setDraftActivities(response.data || []);
     } catch {
-      setErrorLoadingDraftExperiments("Could not load draft activities");
+      setErrorLoadingDraftActivities("Could not load draft activities");
     } finally {
-      setLoadingDraftExperiments(false);
+      setLoadingDraftActivities(false);
     }
   };
 
   useEffect(() => {
     if (!isOpen) return;
-    setSelectedDraftExperimentId(null);
+    setSelectedDraftActivityId(null);
     setPendingNewName(null);
     setActionError(null);
-    loadDraftExperiments();
+    loadDraftActivities();
   }, [isOpen]);
 
   if (!isOpen) return null;
 
   const options: SelectOption[] =
-    draftExperiments?.map((experiment) => ({
-      value: experiment.id,
-      label: experiment.name,
+    draftActivities?.map((activity) => ({
+      value: activity.id,
+      label: activity.name,
     })) || [];
 
   // Valor mostrado en el select
   const selectedOption: SelectOption | null = pendingNewName
     ? { value: `${NEW_OPTION_PREFIX}${pendingNewName}`, label: pendingNewName }
-    : selectedDraftExperimentId
+    : selectedDraftActivityId
     ? {
-        value: selectedDraftExperimentId,
+        value: selectedDraftActivityId,
         label:
-          draftExperiments?.find((exp) => exp.id === selectedDraftExperimentId)
+          draftActivities?.find((activity) => activity.id === selectedDraftActivityId)
             ?.name || "",
       }
     : null;
@@ -86,46 +88,46 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
   const handleChange = (newValue: SingleValue<SelectOption>) => {
     if (!newValue) {
       setPendingNewName(null);
-      setSelectedDraftExperimentId(null);
+      setSelectedDraftActivityId(null);
       return;
     }
     // Si es una opción nueva (creada con el prefijo), no propagamos al padre aún
     if (newValue.value.startsWith(NEW_OPTION_PREFIX)) {
       setPendingNewName(newValue.label);
-      setSelectedDraftExperimentId(null);
+      setSelectedDraftActivityId(null);
     } else {
       setPendingNewName(null);
-      setSelectedDraftExperimentId(newValue.value);
+      setSelectedDraftActivityId(newValue.value);
     }
   };
 
   const handleCreateOption = (inputValue: string) => {
     // Solo guardamos el nombre, NO llamamos a onCreateExperiment todavía
     setPendingNewName(inputValue);
-    setSelectedDraftExperimentId(null);
+    setSelectedDraftActivityId(null);
   };
 
-  const handleAddLeiaToExperiment = async (experimentId: string) => {
+  const handleAddLeiaToActivity = async (activityId: string) => {
     if (!selectedLeia) return;
-    await api.post(`/api/v1/experiments/${experimentId}/leias`, {
+    await api.post(`/api/v1/experiments/${activityId}/leias`, {
       leia: selectedLeia.id,
     });
   };
 
-  const handleCreateExperiment = async (name: string) => {
+  const handleCreateActivity = async (name: string) => {
     const trimmedName = name.trim();
     if (!trimmedName) return null;
 
-    setCreatingNewExperiment(true);
+    setCreatingNewActivity(true);
     try {
       const response = await api.post<Experiment>("/api/v1/experiments", {
         name: trimmedName,
       });
-      setDraftExperiments((prev) => [...(prev || []), response.data]);
-      setSelectedDraftExperimentId(response.data.id);
+      setDraftActivities((prev) => [...(prev || []), response.data]);
+      setSelectedDraftActivityId(response.data.id);
       return response.data.id;
     } finally {
-      setCreatingNewExperiment(false);
+      setCreatingNewActivity(false);
     }
   };
 
@@ -134,25 +136,25 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
     setActionError(null);
 
     try {
-      setAddingLeiaToExperiment(true);
-      let targetExperimentId = selectedDraftExperimentId;
+      setAddingLeiaToActivity(true);
+      let targetActivityId = selectedDraftActivityId;
 
-      if (!targetExperimentId && pendingNewName) {
-        targetExperimentId = await handleCreateExperiment(pendingNewName);
+      if (!targetActivityId && pendingNewName) {
+        targetActivityId = await handleCreateActivity(pendingNewName);
       }
 
-      if (!targetExperimentId) {
+      if (!targetActivityId) {
         setActionError("Select or create an activity first");
         return;
       }
 
-      await handleAddLeiaToExperiment(targetExperimentId);
+      await handleAddLeiaToActivity(targetActivityId);
       handleClose();
       onSuccess?.();
     } catch {
       setActionError("Could not add LEIA to activity");
     } finally {
-      setAddingLeiaToExperiment(false);
+      setAddingLeiaToActivity(false);
     }
   };
 
@@ -162,10 +164,10 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
   };
 
   const canConfirm =
-    (!!selectedDraftExperimentId || !!pendingNewName) &&
+    (!!selectedDraftActivityId || !!pendingNewName) &&
     !!selectedLeia &&
-    !addingLeiaToExperiment &&
-    !creatingNewExperiment;
+    !addingLeiaToActivity &&
+    !creatingNewActivity;
 
   return (
     <div
@@ -185,15 +187,15 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
               Select an Activity
             </label>
 
-            {errorLoadingDraftExperiments ? (
+            {errorLoadingDraftActivities ? (
               <div className="space-y-3">
                 <div className="border border-red-300 rounded-md px-3 py-2 bg-red-50">
                   <p className="text-sm text-red-600">
-                    {errorLoadingDraftExperiments}
+                    {errorLoadingDraftActivities}
                   </p>
                 </div>
                 <button
-                  onClick={loadDraftExperiments}
+                  onClick={loadDraftActivities}
                   className="px-3 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
                 >
                   Try Again
@@ -206,13 +208,13 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
                 onCreateOption={handleCreateOption}
                 options={options}
                 placeholder={
-                  loadingDraftExperiments
+                  loadingDraftActivities
                     ? "Loading activities..."
                     : "Choose or create an activity..."
                 }
                 isClearable
-                isDisabled={creatingNewExperiment || loadingDraftExperiments}
-                isLoading={creatingNewExperiment || loadingDraftExperiments}
+                isDisabled={creatingNewActivity || loadingDraftActivities}
+                isLoading={creatingNewActivity || loadingDraftActivities}
                 formatCreateLabel={(inputValue) =>
                   `Create new activity: "${inputValue}"`
                 }
@@ -234,7 +236,7 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
               />
             )}
 
-            {creatingNewExperiment && (
+            {creatingNewActivity && (
               <div className="mt-2 flex items-center text-sm text-blue-600">
                 <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-blue-600 mr-2"></div>
                 Creating new activity...
@@ -246,7 +248,7 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
             )}
 
             {/* Indicador visual de que es una actividad nueva pendiente */}
-            {pendingNewName && !creatingNewExperiment && (
+            {pendingNewName && !creatingNewActivity && (
               <p className="mt-2 text-sm text-blue-600">
                 New activity "{pendingNewName}" will be created on confirm.
               </p>
@@ -265,10 +267,10 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
               disabled={!canConfirm}
               className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
             >
-              {addingLeiaToExperiment || creatingNewExperiment ? (
+              {addingLeiaToActivity || creatingNewActivity ? (
                 <>
                   <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-white"></div>
-                  {creatingNewExperiment ? "Creating..." : "Adding..."}
+                  {creatingNewActivity ? "Creating..." : "Adding..."}
                 </>
               ) : (
                 "Add to Activity"

--- a/src/components/AddLeiaToAnActivity.tsx
+++ b/src/components/AddLeiaToAnActivity.tsx
@@ -1,0 +1,217 @@
+import React, { useState } from "react";
+import type { SingleValue } from "react-select";
+import CreatableSelect from "react-select/creatable";
+import type { Experiment } from "../models/Experiment";
+import type { Leia } from "../models/Leia";
+
+type SelectOption = {
+  value: string;
+  label: string;
+};
+
+// Prefijo para distinguir opciones nuevas de IDs reales
+const NEW_OPTION_PREFIX = "__new__";
+
+interface AddLeiaToAnActivityProps {
+  isOpen: boolean;
+  selectedLeia: Leia | null;
+  draftExperiments: Experiment[] | null;
+  loadingDraftExperiments: boolean;
+  errorLoadingDraftExperiments: string | null;
+  selectedDraftExperimentId: string | null;
+  creatingNewExperiment: boolean;
+  addingLeiaToExperiment: boolean;
+  onClose: () => void;
+  onRetryLoad: () => void;
+  onSelectDraftExperiment: (id: string | null) => void;
+  onCreateExperiment: (name: string) => void;
+  onConfirmAdd: () => void;
+}
+
+export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
+  isOpen,
+  selectedLeia,
+  draftExperiments,
+  loadingDraftExperiments,
+  errorLoadingDraftExperiments,
+  selectedDraftExperimentId,
+  creatingNewExperiment,
+  addingLeiaToExperiment,
+  onClose,
+  onRetryLoad,
+  onSelectDraftExperiment,
+  onCreateExperiment,
+  onConfirmAdd,
+}) => {
+  const [pendingNewName, setPendingNewName] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const options: SelectOption[] =
+    draftExperiments?.map((experiment) => ({
+      value: experiment.id,
+      label: experiment.name,
+    })) || [];
+
+  // Valor mostrado en el select
+  const selectedOption: SelectOption | null = pendingNewName
+    ? { value: `${NEW_OPTION_PREFIX}${pendingNewName}`, label: pendingNewName }
+    : selectedDraftExperimentId
+    ? {
+        value: selectedDraftExperimentId,
+        label:
+          draftExperiments?.find((exp) => exp.id === selectedDraftExperimentId)
+            ?.name || "",
+      }
+    : null;
+
+  const handleChange = (newValue: SingleValue<SelectOption>) => {
+    if (!newValue) {
+      setPendingNewName(null);
+      onSelectDraftExperiment(null);
+      return;
+    }
+    // Si es una opción nueva (creada con el prefijo), no propagamos al padre aún
+    if (newValue.value.startsWith(NEW_OPTION_PREFIX)) {
+      setPendingNewName(newValue.label);
+      onSelectDraftExperiment(null);
+    } else {
+      setPendingNewName(null);
+      onSelectDraftExperiment(newValue.value);
+    }
+  };
+
+  const handleCreateOption = (inputValue: string) => {
+    // Solo guardamos el nombre, NO llamamos a onCreateExperiment todavía
+    setPendingNewName(inputValue);
+    onSelectDraftExperiment(null);
+  };
+
+  const handleConfirm = () => {
+    if (pendingNewName) {
+      // Aquí sí creamos, justo al pulsar el botón
+      onCreateExperiment(pendingNewName);
+    } else {
+      onConfirmAdd();
+    }
+  };
+
+  const handleClose = () => {
+    setPendingNewName(null);
+    onClose();
+  };
+
+  const canConfirm =
+    (!!selectedDraftExperimentId || !!pendingNewName) &&
+    !!selectedLeia &&
+    !addingLeiaToExperiment;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) handleClose();
+      }}
+    >
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-2xl mx-4">
+        <div className="p-6" onClick={(e) => e.stopPropagation()}>
+          <h2 className="text-xl font-semibold mb-4">
+            Add {selectedLeia?.metadata.name || ""} LEIA to an Activity
+          </h2>
+
+          <div className="mb-6">
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Select an Activity
+            </label>
+
+            {errorLoadingDraftExperiments ? (
+              <div className="space-y-3">
+                <div className="border border-red-300 rounded-md px-3 py-2 bg-red-50">
+                  <p className="text-sm text-red-600">
+                    {errorLoadingDraftExperiments}
+                  </p>
+                </div>
+                <button
+                  onClick={onRetryLoad}
+                  className="px-3 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
+                >
+                  Try Again
+                </button>
+              </div>
+            ) : (
+              <CreatableSelect
+                value={selectedOption}
+                onChange={handleChange}
+                onCreateOption={handleCreateOption}
+                options={options}
+                placeholder={
+                  loadingDraftExperiments
+                    ? "Loading activities..."
+                    : "Choose or create an activity..."
+                }
+                isClearable
+                isDisabled={creatingNewExperiment || loadingDraftExperiments}
+                isLoading={creatingNewExperiment || loadingDraftExperiments}
+                formatCreateLabel={(inputValue) =>
+                  `Create new activity: "${inputValue}"`
+                }
+                createOptionPosition="first"
+                className="react-select-container"
+                classNamePrefix="react-select"
+                styles={{
+                  control: (base) => ({
+                    ...base,
+                    minHeight: "38px",
+                    borderColor: "#d1d5db",
+                    "&:hover": { borderColor: "#9ca3af" },
+                    "&:focus-within": {
+                      borderColor: "#3b82f6",
+                      boxShadow: "0 0 0 1px #3b82f6",
+                    },
+                  }),
+                }}
+              />
+            )}
+
+            {creatingNewExperiment && (
+              <div className="mt-2 flex items-center text-sm text-blue-600">
+                <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-blue-600 mr-2"></div>
+                Creating new activity...
+              </div>
+            )}
+
+            {/* Indicador visual de que es una actividad nueva pendiente */}
+            {pendingNewName && !creatingNewExperiment && (
+              <p className="mt-2 text-sm text-blue-600">
+                New activity "{pendingNewName}" will be created on confirm.
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-3">
+            <button
+              onClick={handleClose}
+              className="px-4 py-2 text-sm border border-gray-300 rounded hover:bg-gray-50 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleConfirm}
+              disabled={!canConfirm}
+              className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+            >
+              {addingLeiaToExperiment || creatingNewExperiment ? (
+                <>
+                  <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-white"></div>
+                  {creatingNewExperiment ? "Creating..." : "Adding..."}
+                </>
+              ) : (
+                "Add to Activity"
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/AddLeiaToAnActivity.tsx
+++ b/src/components/AddLeiaToAnActivity.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import type { SingleValue } from "react-select";
 import CreatableSelect from "react-select/creatable";
 import type { Experiment } from "../models/Experiment";
 import type { Leia } from "../models/Leia";
+import api from "../lib/axios";
 
 type SelectOption = {
   value: string;
@@ -15,35 +16,52 @@ const NEW_OPTION_PREFIX = "__new__";
 interface AddLeiaToAnActivityProps {
   isOpen: boolean;
   selectedLeia: Leia | null;
-  draftExperiments: Experiment[] | null;
-  loadingDraftExperiments: boolean;
-  errorLoadingDraftExperiments: string | null;
-  selectedDraftExperimentId: string | null;
-  creatingNewExperiment: boolean;
-  addingLeiaToExperiment: boolean;
   onClose: () => void;
-  onRetryLoad: () => void;
-  onSelectDraftExperiment: (id: string | null) => void;
-  onCreateExperiment: (name: string) => void;
-  onConfirmAdd: () => void;
+  onSuccess?: () => void;
 }
 
 export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
   isOpen,
   selectedLeia,
-  draftExperiments,
-  loadingDraftExperiments,
-  errorLoadingDraftExperiments,
-  selectedDraftExperimentId,
-  creatingNewExperiment,
-  addingLeiaToExperiment,
   onClose,
-  onRetryLoad,
-  onSelectDraftExperiment,
-  onCreateExperiment,
-  onConfirmAdd,
+  onSuccess,
 }) => {
+  const [draftExperiments, setDraftExperiments] = useState<Experiment[] | null>(
+    null,
+  );
+  const [loadingDraftExperiments, setLoadingDraftExperiments] = useState(false);
+  const [errorLoadingDraftExperiments, setErrorLoadingDraftExperiments] =
+    useState<string | null>(null);
+  const [selectedDraftExperimentId, setSelectedDraftExperimentId] = useState<
+    string | null
+  >(null);
+  const [creatingNewExperiment, setCreatingNewExperiment] = useState(false);
+  const [addingLeiaToExperiment, setAddingLeiaToExperiment] = useState(false);
   const [pendingNewName, setPendingNewName] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const loadDraftExperiments = async () => {
+    setErrorLoadingDraftExperiments(null);
+    try {
+      setLoadingDraftExperiments(true);
+      const response = await api.get<Experiment[]>("/api/v1/experiments/user/me", {
+        params: { visibility: "private" },
+      });
+      setDraftExperiments(response.data || []);
+    } catch {
+      setErrorLoadingDraftExperiments("Could not load draft activities");
+    } finally {
+      setLoadingDraftExperiments(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setSelectedDraftExperimentId(null);
+    setPendingNewName(null);
+    setActionError(null);
+    loadDraftExperiments();
+  }, [isOpen]);
 
   if (!isOpen) return null;
 
@@ -68,31 +86,73 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
   const handleChange = (newValue: SingleValue<SelectOption>) => {
     if (!newValue) {
       setPendingNewName(null);
-      onSelectDraftExperiment(null);
+      setSelectedDraftExperimentId(null);
       return;
     }
     // Si es una opción nueva (creada con el prefijo), no propagamos al padre aún
     if (newValue.value.startsWith(NEW_OPTION_PREFIX)) {
       setPendingNewName(newValue.label);
-      onSelectDraftExperiment(null);
+      setSelectedDraftExperimentId(null);
     } else {
       setPendingNewName(null);
-      onSelectDraftExperiment(newValue.value);
+      setSelectedDraftExperimentId(newValue.value);
     }
   };
 
   const handleCreateOption = (inputValue: string) => {
     // Solo guardamos el nombre, NO llamamos a onCreateExperiment todavía
     setPendingNewName(inputValue);
-    onSelectDraftExperiment(null);
+    setSelectedDraftExperimentId(null);
   };
 
-  const handleConfirm = () => {
-    if (pendingNewName) {
-      // Aquí sí creamos, justo al pulsar el botón
-      onCreateExperiment(pendingNewName);
-    } else {
-      onConfirmAdd();
+  const handleAddLeiaToExperiment = async (experimentId: string) => {
+    if (!selectedLeia) return;
+    await api.post(`/api/v1/experiments/${experimentId}/leias`, {
+      leia: selectedLeia.id,
+    });
+  };
+
+  const handleCreateExperiment = async (name: string) => {
+    const trimmedName = name.trim();
+    if (!trimmedName) return null;
+
+    setCreatingNewExperiment(true);
+    try {
+      const response = await api.post<Experiment>("/api/v1/experiments", {
+        name: trimmedName,
+      });
+      setDraftExperiments((prev) => [...(prev || []), response.data]);
+      setSelectedDraftExperimentId(response.data.id);
+      return response.data.id;
+    } finally {
+      setCreatingNewExperiment(false);
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!selectedLeia) return;
+    setActionError(null);
+
+    try {
+      setAddingLeiaToExperiment(true);
+      let targetExperimentId = selectedDraftExperimentId;
+
+      if (!targetExperimentId && pendingNewName) {
+        targetExperimentId = await handleCreateExperiment(pendingNewName);
+      }
+
+      if (!targetExperimentId) {
+        setActionError("Select or create an activity first");
+        return;
+      }
+
+      await handleAddLeiaToExperiment(targetExperimentId);
+      handleClose();
+      onSuccess?.();
+    } catch {
+      setActionError("Could not add LEIA to activity");
+    } finally {
+      setAddingLeiaToExperiment(false);
     }
   };
 
@@ -104,7 +164,8 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
   const canConfirm =
     (!!selectedDraftExperimentId || !!pendingNewName) &&
     !!selectedLeia &&
-    !addingLeiaToExperiment;
+    !addingLeiaToExperiment &&
+    !creatingNewExperiment;
 
   return (
     <div
@@ -132,7 +193,7 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
                   </p>
                 </div>
                 <button
-                  onClick={onRetryLoad}
+                  onClick={loadDraftExperiments}
                   className="px-3 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
                 >
                   Try Again
@@ -178,6 +239,10 @@ export const AddLeiaToAnActivity: React.FC<AddLeiaToAnActivityProps> = ({
                 <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-blue-600 mr-2"></div>
                 Creating new activity...
               </div>
+            )}
+
+            {actionError && (
+              <p className="mt-2 text-sm text-red-600">{actionError}</p>
             )}
 
             {/* Indicador visual de que es una actividad nueva pendiente */}

--- a/src/screens/CreateLeia.tsx
+++ b/src/screens/CreateLeia.tsx
@@ -11,8 +11,14 @@ import { SelectionColumn } from "../components/shared/SelectionColumn";
 import { Header } from "../components/shared/Header";
 import { ResourceEditor } from "../components/ResourceEditor";
 import { DeleteResourceModal } from "../components/DeleteResourceModal";
+import { AddLeiaToAnActivity } from "../components/AddLeiaToAnActivity";
 import { useAuth } from "../context";
-import type { Persona, Behaviour, Problem } from "../models/Leia";
+import type {
+  Persona,
+  Behaviour,
+  Problem,
+  Leia as LeiaResource,
+} from "../models/Leia";
 import api from "../lib/axios";
 import { generateLeia } from "../lib/leia";
 
@@ -146,6 +152,15 @@ export const CreateLeia: React.FC = () => {
   const [generateDetails, setGenerateDetails] = useState("");
   const [isGenerating, setIsGenerating] = useState(false);
   const [generateError, setGenerateError] = useState<string | null>(null);
+
+  // Modal cuando se pulsa Finish
+  const [showFinishModal, setShowFinishModal] = useState(false);
+  const [createdLeiaName, setCreatedLeiaName] = useState("");
+
+  // Estados para opcionalmente añadir la LEIA a una Activity
+  const [showAddToActivityModal, setShowAddToActivityModal] = useState(false);
+  const [createdLeiaResource, setCreatedLeiaResource] =
+    useState<LeiaResource | null>(null);
 
   // Cargar datos al montar el componente
   useEffect(() => {
@@ -674,7 +689,11 @@ export const CreateLeia: React.FC = () => {
           currentUser?.role === "admin" ? `?publish=${leiaPublish}` : "";
         const response = await api.post(`/api/v1/leias${publishParam}`, leia);
         console.log("LEIA created successfully:", response.data);
-        navigate("/leias");
+        setCreatedLeiaName(
+          response.data?.metadata?.name || customizations.leia.name || "LEIA",
+        );
+        setCreatedLeiaResource(response.data as LeiaResource);
+        setShowFinishModal(true);
       } catch (error) {
         console.error("Error creating LEIA:", error);
         setError("Failed to create LEIA");
@@ -2157,6 +2176,56 @@ export const CreateLeia: React.FC = () => {
         isDeleting={isDeleting}
         error={deleteError}
       />
+
+      <AddLeiaToAnActivity
+        isOpen={showAddToActivityModal}
+        selectedLeia={createdLeiaResource}
+        onClose={() => {setShowAddToActivityModal(false); navigate("/leias")}}
+        onSuccess={() => {
+          setShowAddToActivityModal(false);
+          navigate("/leias");
+        }}
+      />
+
+      {/* Modal mostrado despues de crear la LEIA*/}
+      {showFinishModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4">
+            <div className="p-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                LEIA created successfully
+              </h3>
+              <p className="text-sm text-gray-600">
+                "{createdLeiaName}" was created successfully.
+              </p>
+              <p className="text-sm text-gray-600 mt-2">
+                Do you want to add it directly to an activity?
+              </p>
+            </div>
+
+            <div className="flex gap-3 px-6 py-4 bg-gray-50 rounded-b-xl">
+              <button
+                onClick={() => {
+                  setShowFinishModal(false);
+                  navigate("/leias");
+                }}
+                className="flex-1 px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              >
+                No, go to LEIAs
+              </button>
+              <button
+                onClick={() => {
+                  setShowFinishModal(false);
+                  setShowAddToActivityModal(true);
+                }}
+                className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                Yes, add now
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Modal de generación de problemas con IA */}
       {showGenerateModal && (

--- a/src/screens/LeiaSearch.tsx
+++ b/src/screens/LeiaSearch.tsx
@@ -13,9 +13,9 @@ import { Header } from "../components/shared/Header";
 import type { Leia, Persona, Problem, Behaviour } from "../models/Leia";
 import type { Experiment } from "../models/Experiment";
 import { ToastContainer, toast } from "react-toastify";
-import CreatableSelect from "react-select/creatable";
 import { LeiaViewModal } from "../components/LeiaViewModal";
 import { DeleteLeiaModal } from "../components/DeleteLeiaModal";
+import { AddLeiaToAnActivity } from "../components/AddLeiaToAnActivity";
 import { useAuth } from "../context";
 
 type VersionFilter = "" | "latest";
@@ -190,13 +190,14 @@ export const LeiaSearch: React.FC = () => {
       });
 
       setDraftExperiments((prev) => [...(prev || []), response.data]);
-
       setSelectedDraftExperimentId(response.data.id);
 
       toast.success("Activity '" + response.data.name + "' created", {
         position: "bottom-right",
         autoClose: 5000,
       });
+      
+      await handleAddLeiaToExperiment(response.data.id);
     } catch (error) {
       if (error instanceof Error) {
         toast.error("Could not create new activity: " + error.message, {
@@ -209,11 +210,12 @@ export const LeiaSearch: React.FC = () => {
     }
   };
 
-  const handleAddLeiaToExperiment = async () => {
-    if (!selectedDraftExperimentId || !selectedLeia) return;
+  const handleAddLeiaToExperiment = async (experimentId?: string) => {
+    const targetId = experimentId ?? selectedDraftExperimentId;
+    if (!targetId || !selectedLeia) return;
     try {
       setAddingLeiaToExperiment(true);
-      await api.post(`/api/v1/experiments/${selectedDraftExperimentId}/leias`, {
+      await api.post(`/api/v1/experiments/${targetId}/leias`, {
         leia: selectedLeia.id,
       });
       toast.success("LEIA added to activity successfully", {
@@ -330,145 +332,21 @@ export const LeiaSearch: React.FC = () => {
         description="Discover and test existing LEIA configurations"
       />
       <ToastContainer />
-      {showExperimentsModal && (
-        <div
-          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
-          onClick={(e) => {
-            if (e.target === e.currentTarget) {
-              handleCloseExperimentsModal();
-            }
-          }}
-        >
-          <div className="bg-white rounded-lg shadow-lg w-full max-w-2xl mx-4">
-            <div
-              className="p-6"
-              onClick={(e) => {
-                e.stopPropagation();
-              }}
-            >
-              <h2 className="text-xl font-semibold mb-4">
-                Add {selectedLeia?.metadata.name || ""} LEIA to an Activity
-              </h2>
-
-              {/* Activity Selector */}
-              <div className="mb-6">
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Select an Activity
-                </label>
-
-                {errorLoadingDraftExperiments ? (
-                  <div className="space-y-3">
-                    <div className="border border-red-300 rounded-md px-3 py-2 bg-red-50">
-                      <p className="text-sm text-red-600">
-                        {errorLoadingDraftExperiments}
-                      </p>
-                    </div>
-                    <button
-                      onClick={loadDraftExperiments}
-                      className="px-3 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
-                    >
-                      Try Again
-                    </button>
-                  </div>
-                ) : draftExperiments && draftExperiments.length === 0 ? (
-                  <div className="border border-gray-300 rounded-md px-3 py-2 bg-gray-50">
-                    <p className="text-sm text-gray-600">No activities found</p>
-                  </div>
-                ) : (
-                  <CreatableSelect
-                    value={
-                      selectedDraftExperimentId
-                        ? {
-                            value: selectedDraftExperimentId,
-                            label:
-                              draftExperiments?.find(
-                                (exp) => exp.id === selectedDraftExperimentId
-                              )?.name || "",
-                          }
-                        : null
-                    }
-                    onChange={(newValue) =>
-                      setSelectedDraftExperimentId(newValue?.value || null)
-                    }
-                    onCreateOption={handleCreateExperiment}
-                    options={
-                      draftExperiments?.map((experiment) => ({
-                        value: experiment.id,
-                        label: experiment.name,
-                      })) || []
-                    }
-                    placeholder={
-                      loadingDraftExperiments
-                        ? "Loading activities..."
-                        : "Choose or create an activity..."
-                    }
-                    isClearable
-                    isDisabled={
-                      creatingNewExperiment || loadingDraftExperiments
-                    }
-                    isLoading={creatingNewExperiment || loadingDraftExperiments}
-                    formatCreateLabel={(inputValue) =>
-                      `Create activity: "${inputValue}"`
-                    }
-                    createOptionPosition="first"
-                    className="react-select-container"
-                    classNamePrefix="react-select"
-                    styles={{
-                      control: (base) => ({
-                        ...base,
-                        minHeight: "38px",
-                        borderColor: "#d1d5db",
-                        "&:hover": {
-                          borderColor: "#9ca3af",
-                        },
-                        "&:focus-within": {
-                          borderColor: "#3b82f6",
-                          boxShadow: "0 0 0 1px #3b82f6",
-                        },
-                      }),
-                    }}
-                  />
-                )}
-
-                {creatingNewExperiment && (
-                  <div className="mt-2 flex items-center text-sm text-blue-600">
-                    <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-blue-600 mr-2"></div>
-                    Creating new activity...
-                  </div>
-                )}
-              </div>
-
-              {/* Action Buttons */}
-              <div className="flex justify-end gap-3">
-                <button
-                  onClick={handleCloseExperimentsModal}
-                  className="px-4 py-2 text-sm border border-gray-300 rounded hover:bg-gray-50 transition-colors"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleAddLeiaToExperiment}
-                  disabled={
-                    !selectedDraftExperimentId ||
-                    !selectedLeia ||
-                    addingLeiaToExperiment
-                  }
-                  className="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
-                >
-                  {addingLeiaToExperiment ? (
-                    <>
-                      <div className="animate-spin rounded-full h-3 w-3 border-b-2 border-white"></div>
-                      Adding...
-                    </>
-                  ) : (
-                    "Add to Activity"
-                  )}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      <AddLeiaToAnActivity
+        isOpen={showExperimentsModal}
+        selectedLeia={selectedLeia}
+        draftExperiments={draftExperiments}
+        loadingDraftExperiments={loadingDraftExperiments}
+        errorLoadingDraftExperiments={errorLoadingDraftExperiments}
+        selectedDraftExperimentId={selectedDraftExperimentId}
+        creatingNewExperiment={creatingNewExperiment}
+        addingLeiaToExperiment={addingLeiaToExperiment}
+        onClose={handleCloseExperimentsModal}
+        onRetryLoad={loadDraftExperiments}
+        onSelectDraftExperiment={setSelectedDraftExperimentId}
+        onCreateExperiment={handleCreateExperiment}
+        onConfirmAdd={handleAddLeiaToExperiment}
+      />
       <div className="max-w-6xl mx-auto pt-6 px-6 w-full mx-auto">
         <div className="flex items-end justify-between mb-6">
           <div className="flex-1">

--- a/src/screens/LeiaSearch.tsx
+++ b/src/screens/LeiaSearch.tsx
@@ -11,7 +11,6 @@ import api from "../lib/axios";
 import { SearchFilter } from "../components/shared/SearchFilter";
 import { Header } from "../components/shared/Header";
 import type { Leia, Persona, Problem, Behaviour } from "../models/Leia";
-import type { Experiment } from "../models/Experiment";
 import { ToastContainer, toast } from "react-toastify";
 import { LeiaViewModal } from "../components/LeiaViewModal";
 import { DeleteLeiaModal } from "../components/DeleteLeiaModal";
@@ -42,19 +41,7 @@ export const LeiaSearch: React.FC = () => {
     return p;
   }, [queryText, versionFilter, visibilityFilter]);
 
-  const [draftExperiments, setDraftExperiments] = useState<Experiment[] | null>(
-    null
-  );
-  const [loadingDraftExperiments, setLoadingDraftExperiments] = useState(false);
-  const [errorLoadingDraftExperiments, setErrorLoadingDraftExperiments] =
-    useState<string | null>(null);
-  const [selectedDraftExperimentId, setSelectedDraftExperimentId] = useState<
-    string | null
-  >(null);
-  const [addingLeiaToExperiment, setAddingLeiaToExperiment] = useState(false);
   const [selectedLeia, setSelectedLeia] = useState<Leia | null>(null);
-
-  const [creatingNewExperiment, setCreatingNewExperiment] = useState(false);
   const [showExperimentsModal, setShowExperimentsModal] = useState(false);
 
   // Estados para el modal de visualización de LEIA
@@ -149,90 +136,13 @@ export const LeiaSearch: React.FC = () => {
     }
   };
 
-  const loadDraftExperiments = async () => {
-    setErrorLoadingDraftExperiments(null);
-    try {
-      setLoadingDraftExperiments(true);
-      const response = await api.get<Experiment[]>(
-        "/api/v1/experiments/user/me",
-        {
-          params: { visibility: "private" },
-        }
-      );
-      setDraftExperiments(response.data);
-    } catch {
-      setErrorLoadingDraftExperiments("Could not load draft activities");
-    } finally {
-      setLoadingDraftExperiments(false);
-    }
-  };
-
   const handleOpenExperimentsModal = () => {
-    if (!draftExperiments) {
-      loadDraftExperiments();
-    }
     setShowExperimentsModal(true);
   };
 
   const handleCloseExperimentsModal = () => {
     setShowExperimentsModal(false);
-    setSelectedDraftExperimentId(null);
     setSelectedLeia(null);
-  };
-
-  const handleCreateExperiment = async (inputValue: string) => {
-    if (!inputValue.trim()) return;
-
-    try {
-      setCreatingNewExperiment(true);
-      const response = await api.post<Experiment>("/api/v1/experiments", {
-        name: inputValue.trim(),
-      });
-
-      setDraftExperiments((prev) => [...(prev || []), response.data]);
-      setSelectedDraftExperimentId(response.data.id);
-
-      toast.success("Activity '" + response.data.name + "' created", {
-        position: "bottom-right",
-        autoClose: 5000,
-      });
-      
-      await handleAddLeiaToExperiment(response.data.id);
-    } catch (error) {
-      if (error instanceof Error) {
-        toast.error("Could not create new activity: " + error.message, {
-          position: "bottom-right",
-          autoClose: 5000,
-        });
-      }
-    } finally {
-      setCreatingNewExperiment(false);
-    }
-  };
-
-  const handleAddLeiaToExperiment = async (experimentId?: string) => {
-    const targetId = experimentId ?? selectedDraftExperimentId;
-    if (!targetId || !selectedLeia) return;
-    try {
-      setAddingLeiaToExperiment(true);
-      await api.post(`/api/v1/experiments/${targetId}/leias`, {
-        leia: selectedLeia.id,
-      });
-      toast.success("LEIA added to activity successfully", {
-        position: "bottom-right",
-        autoClose: 5000,
-      });
-      handleCloseExperimentsModal();
-    } catch (error) {
-      if (error instanceof Error) {
-        toast.error("Could not add LEIA to activity: " + error.message, {
-          position: "bottom-right",
-          autoClose: 5000,
-        });
-      }
-    } finally {
-      setAddingLeiaToExperiment(false);
-    }
   };
 
   const handleViewLeiaContent = useCallback((leia: Leia) => {
@@ -335,17 +245,14 @@ export const LeiaSearch: React.FC = () => {
       <AddLeiaToAnActivity
         isOpen={showExperimentsModal}
         selectedLeia={selectedLeia}
-        draftExperiments={draftExperiments}
-        loadingDraftExperiments={loadingDraftExperiments}
-        errorLoadingDraftExperiments={errorLoadingDraftExperiments}
-        selectedDraftExperimentId={selectedDraftExperimentId}
-        creatingNewExperiment={creatingNewExperiment}
-        addingLeiaToExperiment={addingLeiaToExperiment}
         onClose={handleCloseExperimentsModal}
-        onRetryLoad={loadDraftExperiments}
-        onSelectDraftExperiment={setSelectedDraftExperimentId}
-        onCreateExperiment={handleCreateExperiment}
-        onConfirmAdd={handleAddLeiaToExperiment}
+        onSuccess={() => {
+          toast.success("LEIA added to activity successfully", {
+            position: "bottom-right",
+            autoClose: 5000,
+          });
+          handleCloseExperimentsModal();
+        }}
       />
       <div className="max-w-6xl mx-auto pt-6 px-6 w-full mx-auto">
         <div className="flex items-end justify-between mb-6">


### PR DESCRIPTION
Se refactorizó el flujo de Add LEIA to Activity en un modal reutilizable "AddLeiaToAnActivity" con lógica interna de carga, creación y asociación de actividades.
Se integró en LeiaSearch y CreateLeia, eliminando duplicación; además, en CreateLeia se añadió confirmación post-Finish para añadir la LEIA recién creada directamente a una actividad.
Se arreglo un fallo que permitía crear actividades del modal de creacion de actividades sin linkear estas con la LEIA