### PR TITLE
feat: quick replication button in activities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 VITE_APP_BACKEND=http://localhost:3000
+VITE_WORKBENCH_URL=http://localhost:8080

--- a/src/screens/MyActivities.tsx
+++ b/src/screens/MyActivities.tsx
@@ -1392,7 +1392,7 @@ export const MyActivities: React.FC = () => {
                             )}
                             {experiment.isPublished &&<button 
                               onClick={() => handleFastReplication(experiment.id)}
-                              className="h-8 px-3 text-xs font-medium rounded-md bg-gradient-to-r from-purple-600 to-blue-600 text-white hover:from-purple-700 hover:to-blue-700 transition-colors duration-200 flex items-center gap-1"
+                              className="h-8 px-3 text-xs font-medium rounded-md bg-purple-600 text-white hover:bg-purple-700 transition-colors duration-200 flex items-center gap-1"
                               title="Replicate activity"
                             >
                               Replicate

--- a/src/screens/MyActivities.tsx
+++ b/src/screens/MyActivities.tsx
@@ -325,6 +325,20 @@ export const MyActivities: React.FC = () => {
     }
   };
 
+  const handleFastReplication = (experimentId: string) => {
+    const workbenchBaseUrl =
+      import.meta.env.VITE_WORKBENCH_URL;
+
+    const replicationUrl = `${workbenchBaseUrl.replace(/\/$/, "")}/experiments/${encodeURIComponent(experimentId)}`;
+    const newWindow = window.open(replicationUrl);
+    if (!newWindow) {
+      toast.error("Popup blocked or could not open replication", {
+        position: "bottom-right",
+        autoClose: 2000,
+      });
+    }
+  };
+
   const handleUpdateExperimentLeiaMode = async (
     experimentId: string,
     leiaConfigId: string,
@@ -1376,6 +1390,13 @@ export const MyActivities: React.FC = () => {
                                 Published
                               </span>
                             )}
+                            {experiment.isPublished &&<button 
+                              onClick={() => handleFastReplication(experiment.id)}
+                              className="h-8 px-3 text-xs font-medium rounded-md bg-gradient-to-r from-purple-600 to-blue-600 text-white hover:from-purple-700 hover:to-blue-700 transition-colors duration-200 flex items-center gap-1"
+                              title="Replicate activity"
+                            >
+                              Replicate
+                            </button>}
                             {!experiment.isPublished && (
                               <div className="flex items-center gap-2">
                                 <button


### PR DESCRIPTION
Added a button to activities that, when an activity is published, lets you open the Workbench frontend to start the replication.