### PR TITLE
fix(codeEditor): PyScript Python runner crash + restore Try tool-capable restriction

### DIFF
--- a/src/components/LeiaTryDropdown.tsx
+++ b/src/components/LeiaTryDropdown.tsx
@@ -12,6 +12,7 @@ interface LeiaTryDropdownProps {
   apiKeyValue: string | null;
   models: string[];
   apiKeys: ApiKey[];
+  toolsRestricted?: boolean;
   onModelChange: (value: string) => void;
   onApiKeyChange: (value: string | null) => void;
   canStart: boolean;
@@ -31,6 +32,7 @@ export const LeiaTryDropdown: React.FC<LeiaTryDropdownProps> = ({
   apiKeyValue,
   models,
   apiKeys,
+  toolsRestricted,
   onModelChange,
   onApiKeyChange,
   canStart,
@@ -48,6 +50,12 @@ export const LeiaTryDropdown: React.FC<LeiaTryDropdownProps> = ({
         <div className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
           Try settings
         </div>
+        {toolsRestricted && (
+          <div className="mt-2 rounded-md bg-amber-50 border border-amber-200 px-2.5 py-1.5 text-[11px] text-amber-700">
+            This activity uses widgets, so its tool-functions only run on a
+            tool-capable provider. Only OpenAI models are available here.
+          </div>
+        )}
         <div className="mt-2">
           <label className="block text-xs font-medium text-gray-600 mb-1">
             Model

--- a/src/screens/CreateLeia.tsx
+++ b/src/screens/CreateLeia.tsx
@@ -112,6 +112,7 @@ export const CreateLeia: React.FC = () => {
   } = useApiKeys();
   const {
     apiKeyProvidersMapped,
+    providerProviderModuleMap,
     defaultModel,
     isLoading: isProvidersLoading,
     error: providersError,
@@ -1341,10 +1342,30 @@ const openGenerateProblemModal = () => {
 
   const renderStep2 = () => {
     const isTryLoading = isApiKeysLoading || isProvidersLoading;
-    const validTryModels = getValidModels(tryConfig.apiKeyId);
-    const validTryApiKeys = getValidApiKeys(tryConfig.modelName);
+    // Widgets / tool-functions only work through a tool-capable runner provider
+    // (the openai-responses module). When the problem declares widgets, the Try
+    // is restricted to those models/keys — today that means OpenAI.
+    const problemHasWidgets =
+      Array.isArray(leiaConfig.problem?.spec?.widgets) &&
+      (leiaConfig.problem?.spec?.widgets?.length ?? 0) > 0;
+    const toolCapableProviders = Object.entries(providerProviderModuleMap || {})
+      .filter(([, moduleName]) => moduleName === "openai-responses")
+      .map(([provider]) => provider);
+    const toolCapableModels = toolCapableProviders.flatMap(
+      (provider) => apiKeyProvidersMapped[provider] || []
+    );
+    let validTryModels = getValidModels(tryConfig.apiKeyId);
+    let validTryApiKeys = getValidApiKeys(tryConfig.modelName);
+    if (problemHasWidgets) {
+      validTryModels = validTryModels.filter((m) => toolCapableModels.includes(m));
+      validTryApiKeys = validTryApiKeys.filter((k) =>
+        toolCapableProviders.includes(k.provider)
+      );
+    }
     const canStartTry =
-      Boolean(tryConfig.modelName && tryConfig.apiKeyId) && !isTryLoading;
+      Boolean(tryConfig.modelName && tryConfig.apiKeyId) &&
+      !isTryLoading &&
+      (!problemHasWidgets || toolCapableModels.includes(tryConfig.modelName));
     const showNoApiKeys =
       !isTryLoading &&
       !providersError &&
@@ -1745,6 +1766,7 @@ const openGenerateProblemModal = () => {
                   apiKeyValue={tryConfig.apiKeyId}
                   models={validTryModels}
                   apiKeys={validTryApiKeys}
+                  toolsRestricted={problemHasWidgets}
                   onModelChange={handleTryModelChange}
                   onApiKeyChange={handleTryApiKeyChange}
                   canStart={canStartTry}

--- a/src/widgets/codeEditor/pyRunner.ts
+++ b/src/widgets/codeEditor/pyRunner.ts
@@ -18,6 +18,24 @@ interface DonkeyOptions {
 
 let donkeyPromise: Promise<DonkeyInstance> | null = null;
 
+const HIDDEN_TERMINAL_ID = "leia-py-hidden-terminal";
+
+// donkey always pipes Python stdout/stderr into a terminal element, and its
+// execute()/evaluate() helpers fail if that target is missing. The previous
+// `config: { terminal: false }` left the terminal null and broke every run with
+// `'JsNull' object has no attribute 'terminal'`. Per the PyScript docs, the
+// supported way to keep the terminal off-screen is to point the top-level
+// `terminal` option at a hidden (display:none) container.
+function ensureHiddenTerminal(): string {
+    if (typeof document !== "undefined" && !document.getElementById(HIDDEN_TERMINAL_ID)) {
+        const el = document.createElement("div");
+        el.id = HIDDEN_TERMINAL_ID;
+        el.style.display = "none";
+        document.body.appendChild(el);
+    }
+    return `#${HIDDEN_TERMINAL_ID}`;
+}
+
 function loadDonkey(): Promise<DonkeyInstance> {
     if (donkeyPromise) return donkeyPromise;
     donkeyPromise = (async () => {
@@ -29,13 +47,10 @@ function loadDonkey(): Promise<DonkeyInstance> {
         const instance = await mod.donkey({
             type: "py",
             persistent: true,
-            // Disable the auto-injected <py-terminal> element. PyScript
-            // creates it via the inner script's config; setting
-            // config.terminal=false at the PyScript level prevents the
-            // DOM injection (the top-level `terminal` option is just a
-            // CSS selector for an existing element and doesn't disable).
-            config: { terminal: false },
-        } as unknown as DonkeyOptions);
+            // Off-screen terminal target so donkey has a valid (but invisible)
+            // place to render output; execute()/evaluate() need it to exist.
+            terminal: ensureHiddenTerminal(),
+        });
         return instance;
     })();
     return donkeyPromise;


### PR DESCRIPTION
## Fixes

**1. Python runner crash (`'JsNull' object has no attribute 'terminal'`)**
The code-editor widget's Python test runner started donkey with `config: { terminal: false }`, which leaves donkey's terminal target null; its `execute()`/`evaluate()` then crash on every run. Per the PyScript docs the supported way to keep the terminal off-screen is to point the top-level `terminal` option at a hidden (`display:none`) container. `pyRunner.ts` now creates a hidden div and passes `terminal: "#..."`.

**2. Re-land Try tool-capable restriction (was orphaned)**
The commit restricting the Try model/key selection to tool-capable providers (OpenAI) when the problem has widgets was pushed after PR #65 had already merged, so it never reached `develop`. Re-applied here: when the problem declares widgets, the Try only offers `openai-responses`-module models/keys, gates Start, and shows a notice.

## Verification

`tsc -b` + `vite build` OK. The Python path needs a browser to fully verify (PyScript/Pyodide loads at runtime); the donkey terminal target now follows the documented hidden-container pattern.