### PR TITLE
feat(problem-chat): full Problem schema + widgets/tools in apply_problem; fix Try model/key seeding

### DIFF
--- a/src/components/ProblemChatPanel.tsx
+++ b/src/components/ProblemChatPanel.tsx
@@ -8,6 +8,7 @@ import {
 import type { Problem, ProblemSpec } from "../models/Leia";
 import { useApiKeys } from "../hooks/useApiKeys";
 import { useProviders } from "../hooks/useProviders";
+import { WIDGET_CATALOG } from "../widgets/catalog";
 import {
   openProblemChat,
   uploadProblemChatFile,
@@ -17,21 +18,40 @@ import {
   type UploadedFile,
 } from "../lib/problemChat";
 
-// The editor-driving tools the model can call. apply_problem's parameters ARE
-// the Problem spec — structured output via function calling (same pattern as the
-// workbench widget tools). get_current_problem lets the model read the editor
-// to iterate on an existing problem.
+// Widget catalog context for the model: available widgetTypes + their tool
+// functions, so it can decide whether the activity needs a widget (e.g. a
+// coding exercise) and configure each tool's usage.
+const WIDGET_TYPES = WIDGET_CATALOG.map((w) => w.widgetType);
+const WIDGET_TOOL_NAMES = Array.from(
+  new Set(WIDGET_CATALOG.flatMap((w) => w.tools.map((t) => t.name))),
+);
+const WIDGET_CATALOG_DOC = WIDGET_CATALOG.length
+  ? WIDGET_CATALOG.map(
+      (w) =>
+        `- "${w.widgetType}": ${w.description} Tools: ${w.tools
+          .map((t) => `${t.name} (${t.description})`)
+          .join("; ")}`,
+    ).join("\n")
+  : "(none available)";
+
+// The editor-driving tools. apply_problem's parameters ARE the full Problem
+// spec (structured output via function calling, like the workbench widget
+// tools). get_current_problem lets the model read the editor to iterate.
 const CHAT_TOOLS: ProblemChatTool[] = [
   {
     name: "get_current_problem",
     description:
-      "Returns the problem currently in the editor (its spec fields). Call it before modifying an existing problem, or to match its style/solutionFormat.",
+      "Returns the problem currently in the editor (its full spec, including any widgets). Call it before modifying an existing problem, or to match its style/solutionFormat.",
     parameters: { type: "object", properties: {} },
   },
   {
     name: "apply_problem",
     description:
-      "Writes a COMPLETE problem into the editor, replacing the current one. Call it once you have enough information (from the conversation and/or an attached PDF) to produce a coherent problem.",
+      "Writes a COMPLETE problem into the editor, replacing the current one. Fill every field you reasonably can.\n\n" +
+      "Advanced fields — leave as empty objects {} unless explicitly composing: `extends` (inherit from a base problem), `overrides` (override inherited fields), `constrainedTo` (constraints on the interaction/solution).\n\n" +
+      "Add `widgets` ONLY when the activity needs an interactive tool (e.g. a coding exercise needs the code editor). Available widgets and their tool functions:\n" +
+      WIDGET_CATALOG_DOC +
+      "\nFor each widget tool you may set `enabled` and a `usage` note telling LEIA when to use it in this activity.",
     parameters: {
       type: "object",
       properties: {
@@ -42,15 +62,66 @@ const CHAT_TOOLS: ProblemChatTool[] = [
         },
         details: { type: "string", description: "Specific requirements, constraints and expected features." },
         solution: { type: "string", description: "The expected solution, in the chosen solutionFormat." },
+        initialSolution: {
+          type: "string",
+          description: "Optional starting solution shown to the student (empty string if none).",
+        },
         solutionFormat: {
           type: "string",
           enum: ["text", "mermaid", "yaml", "markdown", "html", "json", "xml"],
           description: "Format of the solution (use 'mermaid' for diagrams).",
         },
+        evaluationPrompt: {
+          type: "string",
+          description: "Optional instructions for grading the student's solution (empty string if none).",
+        },
         process: {
           type: "array",
-          items: { type: "string" },
-          description: "Optional process tags, e.g. ['requirements-elicitation'].",
+          items: { type: "string", enum: ["requirements-elicitation", "game", "other"] },
+          description: "Optional process tags.",
+        },
+        extends: {
+          type: "object",
+          description: "Advanced: inherit from a base problem/template. Empty object {} unless explicitly composing.",
+        },
+        overrides: {
+          type: "object",
+          description: "Advanced: field overrides applied on top of `extends`. Empty object {} unless overriding.",
+        },
+        constrainedTo: {
+          type: "object",
+          description: "Advanced: constraints on the interaction/solution. Empty object {} unless constraining.",
+        },
+        widgets: {
+          type: "array",
+          description:
+            "Interactive widgets for the activity (and their tool functions). Include ONLY if the activity needs one.",
+          items: {
+            type: "object",
+            properties: {
+              widgetType: { type: "string", enum: WIDGET_TYPES, description: "Which widget." },
+              slot: { type: "string", enum: ["left", "right", "main"], description: "Where it mounts." },
+              params: {
+                type: "object",
+                description:
+                  "Widget configuration. codeEditor: { fnName, description, starter: { javascript, python }, tests: [{ name, args, expected }] }.",
+              },
+              tools: {
+                type: "array",
+                description: "Per-tool config for this widget's tool functions.",
+                items: {
+                  type: "object",
+                  properties: {
+                    name: { type: "string", enum: WIDGET_TOOL_NAMES, description: "The tool function." },
+                    enabled: { type: "boolean", description: "Whether LEIA may use it (default true)." },
+                    usage: { type: "string", description: "When LEIA should use this tool in this activity." },
+                  },
+                  required: ["name"],
+                },
+              },
+            },
+            required: ["widgetType"],
+          },
         },
       },
       required: ["description", "personaBackground", "details", "solution"],

--- a/src/screens/CreateLeia.tsx
+++ b/src/screens/CreateLeia.tsx
@@ -844,22 +844,53 @@ const openGenerateProblemModal = () => {
   );
 
   const ensureTryConfig = useCallback(() => {
+    // When the problem declares widgets, tools only run on a tool-capable
+    // provider (openai-responses), so the Try must seed an OpenAI model/key —
+    // even if the user's DEFAULT key belongs to another provider.
+    const problemWidgets = leiaConfig.problem?.spec?.widgets;
+    const requiresTools = Array.isArray(problemWidgets) && problemWidgets.length > 0;
+    const toolCapableProviders = Object.entries(providerProviderModuleMap || {})
+      .filter(([, moduleName]) => moduleName === "openai-responses")
+      .map(([provider]) => provider);
+    const toolCapableModels = toolCapableProviders.flatMap(
+      (provider) => apiKeyProvidersMapped[provider] || []
+    );
+    const candidateKeys = requiresTools
+      ? apiKeys.filter((key) => toolCapableProviders.includes(key.provider))
+      : apiKeys;
+
     setTryConfig((prev) => {
-      if (prev.modelName || prev.apiKeyId) return prev;
+      const prevKeyValid = Boolean(prev.apiKeyId && candidateKeys.some((k) => k.id === prev.apiKeyId));
+      const prevModelValid = Boolean(
+        prev.modelName && (!requiresTools || toolCapableModels.includes(prev.modelName))
+      );
+      // Keep a still-valid selection; otherwise (re)seed from the candidates.
+      if ((prev.modelName || prev.apiKeyId) && prevKeyValid && prevModelValid) {
+        return prev;
+      }
 
       const defaultKey = getDefaultKey();
-      const validModels = getValidModels(defaultKey?.id);
-      const resolvedDefaultModel =
+      const key =
+        defaultKey && candidateKeys.some((k) => k.id === defaultKey.id)
+          ? defaultKey
+          : candidateKeys[0] ?? null;
+      const validModels = requiresTools ? toolCapableModels : getValidModels(key?.id);
+      const model =
         defaultModel && validModels.includes(defaultModel)
           ? defaultModel
-          : "";
+          : validModels[0] ?? "";
 
-      return {
-        modelName: resolvedDefaultModel,
-        apiKeyId: defaultKey?.id ?? null,
-      };
+      return { modelName: model, apiKeyId: key?.id ?? null };
     });
-  }, [defaultModel, getDefaultKey, getValidModels]);
+  }, [
+    leiaConfig.problem,
+    providerProviderModuleMap,
+    apiKeyProvidersMapped,
+    apiKeys,
+    defaultModel,
+    getDefaultKey,
+    getValidModels,
+  ]);
 
   const handleTryMenuToggle = useCallback(() => {
     if (testingLeia) return;
@@ -1233,7 +1264,14 @@ const openGenerateProblemModal = () => {
             name: prev.problem?.metadata?.name || "ai-generated-problem",
             version: "1.0.0",
           },
-          spec: { ...incomingSpec, extends: {}, overrides: {}, constrainedTo: {} },
+          // Preserve extends/overrides/constrainedTo and widgets the model set;
+          // default the composition objects to {} only when absent.
+          spec: {
+            ...incomingSpec,
+            extends: incomingSpec.extends ?? {},
+            overrides: incomingSpec.overrides ?? {},
+            constrainedTo: incomingSpec.constrainedTo ?? {},
+          },
           id: `generated-${Date.now()}`,
           edited: true,
           createdAt: new Date().toISOString(),


### PR DESCRIPTION
## What

1. **Full Problem schema for the assistant.** `apply_problem` now exposes the complete spec so the model can author everything, not just the basics:
   - `description, personaBackground, details, solution, initialSolution, solutionFormat, evaluationPrompt, process`
   - `extends` / `overrides` / `constrainedTo` (advanced composition — the tool description tells the model to leave them `{}` unless explicitly composing).
   - `widgets` (+ their tool functions), built from the designer widget catalog: the model is shown the available widgets (e.g. `codeEditor`) and their tool functions (`codeEditor_read/applyDiff/runTests`), and may set each tool's `enabled` + `usage`. It adds widgets only when the activity needs one.
   - `applyChatProblem` no longer clobbers `extends/overrides/constrainedTo` with `{}` — it preserves whatever the model produced (and the widgets).

2. **Fix Try model/key seeding for tool-capable activities.** When the problem has widgets, the Try is restricted to OpenAI; but if the user's DEFAULT key was another provider the selectors ended up empty ("No API keys match the selected model") even though an OpenAI key existed. `ensureTryConfig` now seeds (and re-seeds, if the current selection is invalid) from the tool-capable (OpenAI) keys/models in that case.

## Verification
`tsc -b` + `vite build` OK. Pairs with a small leia-runner PR that adds matching guidance to the assistant's system prompt.