### PR TITLE
fix: keep Designer try widgets and Python runner working

### DIFF
--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -20,6 +20,8 @@ const CHAT_SAVE_STATE_KEY = "designerChatSaveState";
 const EDIT_STATE_KEY = "designerEditState";
 
 interface NavigationState {
+  problem?: unknown;
+  leia?: unknown;
   preset?: {
     persona?: unknown;
     problem?: unknown;
@@ -101,13 +103,24 @@ function extractWidgetsFromState(
   navState: NavigationState | null,
 ): ProblemWidget[] | undefined {
   const fromProblem = (p: unknown): ProblemWidget[] | undefined => {
-    const widgets = (p as { spec?: { widgets?: ProblemWidget[] } } | null | undefined)
-      ?.spec?.widgets;
+    const problem = p as
+      | { spec?: { widgets?: ProblemWidget[] }; widgets?: ProblemWidget[] }
+      | null
+      | undefined;
+    const widgets = problem?.spec?.widgets ?? problem?.widgets;
     return Array.isArray(widgets) && widgets.length > 0 ? widgets : undefined;
   };
+  const fromLeia = (leia: unknown): ProblemWidget[] | undefined =>
+    fromProblem(
+      (leia as { spec?: { problem?: unknown } } | null | undefined)?.spec
+        ?.problem,
+    );
   return (
+    fromProblem(navState?.problem) ??
+    fromLeia(navState?.leia) ??
     fromProblem(navState?.save?.leiaConfig?.problem) ??
-    fromProblem(navState?.preset?.problem)
+    fromProblem(navState?.preset?.problem) ??
+    fromLeia(navState?.experimentTranscription?.leiaConfig?.leia)
   );
 }
 

--- a/src/screens/LeiaSearch.tsx
+++ b/src/screens/LeiaSearch.tsx
@@ -265,6 +265,7 @@ export const LeiaSearch: React.FC = () => {
         navigate(`/chat/${sessionId}`, {
           state: {
             problemDescription: leia.spec?.problem?.spec?.description || "",
+            problem: leia.spec?.problem,
           },
         });
       } else {

--- a/src/widgets/codeEditor/pyRunner.ts
+++ b/src/widgets/codeEditor/pyRunner.ts
@@ -18,27 +18,25 @@ interface DonkeyOptions {
 
 let donkeyPromise: Promise<DonkeyInstance> | null = null;
 
-const HIDDEN_TERMINAL_ID = "leia-py-hidden-terminal";
+const HIDDEN_TERMINAL_STYLE_ID = "leia-py-terminal-hidden-style";
 
-// donkey always pipes Python stdout/stderr into a terminal element, and its
-// execute()/evaluate() helpers fail if that target is missing. The previous
-// `config: { terminal: false }` left the terminal null and broke every run with
-// `'JsNull' object has no attribute 'terminal'`. Per the PyScript docs, the
-// supported way to keep the terminal off-screen is to point the top-level
-// `terminal` option at a hidden (display:none) container.
-function ensureHiddenTerminal(): string {
-    if (typeof document !== "undefined" && !document.getElementById(HIDDEN_TERMINAL_ID)) {
-        const el = document.createElement("div");
-        el.id = HIDDEN_TERMINAL_ID;
-        el.style.display = "none";
-        document.body.appendChild(el);
+// donkey always pipes Python stdout/stderr into a terminal. Passing a null or
+// unresolved terminal target makes Pyodide fail inside stdio with
+// `'JsNull' object has no attribute 'terminal'`. Let PyScript create its
+// default terminal, but hide that terminal before the module loads.
+function hideAutoTerminal(): void {
+    if (typeof document !== "undefined" && !document.getElementById(HIDDEN_TERMINAL_STYLE_ID)) {
+        const style = document.createElement("style");
+        style.id = HIDDEN_TERMINAL_STYLE_ID;
+        style.textContent = "py-terminal { display: none !important; }";
+        document.head.appendChild(style);
     }
-    return `#${HIDDEN_TERMINAL_ID}`;
 }
 
 function loadDonkey(): Promise<DonkeyInstance> {
     if (donkeyPromise) return donkeyPromise;
     donkeyPromise = (async () => {
+        hideAutoTerminal();
         // Dynamic import from the CDN — the URL is intentionally external
         // and not bundled by Vite. Tell Vite to leave it alone.
         const url = "https://pyscript.net/releases/2026.3.1/core.js";
@@ -47,9 +45,6 @@ function loadDonkey(): Promise<DonkeyInstance> {
         const instance = await mod.donkey({
             type: "py",
             persistent: true,
-            // Off-screen terminal target so donkey has a valid (but invisible)
-            // place to render output; execute()/evaluate() need it to exist.
-            terminal: ensureHiddenTerminal(),
         });
         return instance;
     })();


### PR DESCRIPTION
Summary:
- Hide PyScript's auto terminal instead of passing a terminal selector, avoiding JsNull terminal errors in Python tests.
- Preserve problem widgets in Designer Try when launched from LEIA search or alternate navigation state shapes.

Checks:
- npm run build

Notes:
- Targeted ESLint still reports existing unrelated errors in Chat.tsx/LeiaSearch.tsx.