### PR TITLE
feat: use centralized Auth session

### DIFF
--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { jwtDecode } from "jwt-decode";
 import { AuthContext, type AuthContextType } from "./AuthContext";
 import type { DecodedToken } from "../models";
+import { setAuthToken } from "../lib/authToken";
 
 interface AuthProviderProps {
   children: ReactNode;
@@ -15,16 +16,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
 
-  const isTokenExpired = (token: string): boolean => {
-    try {
-      const decoded = jwtDecode<DecodedToken>(token);
-      const currentTime = Date.now() / 1000;
-      return decoded.exp < currentTime;
-    } catch {
-      return true;
-    }
-  };
-
   const decodeToken = (token: string): DecodedToken | null => {
     try {
       return jwtDecode<DecodedToken>(token);
@@ -34,49 +25,67 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   };
 
-  const login = (newToken: string) => {
-    localStorage.setItem("token", newToken);
+  const login = useCallback((newToken: string) => {
+    setAuthToken(newToken);
     setToken(newToken);
     const decoded = decodeToken(newToken);
     setUser(decoded);
-  };
-
-  const logout = useCallback(() => {
-    localStorage.removeItem("token");
-    setToken(null);
-    setUser(null);
-    navigate("/login");
-  }, [navigate]);
-
-  useEffect(() => {
-    const storedToken = localStorage.getItem("token");
-
-    if (storedToken) {
-      if (isTokenExpired(storedToken)) {
-        localStorage.removeItem("token");
-        setToken(null);
-        setUser(null);
-      } else {
-        const decoded = decodeToken(storedToken);
-        setToken(storedToken);
-        setUser(decoded);
-      }
-    }
-
-    setIsLoading(false);
   }, []);
 
-  useEffect(() => {
-    if (!token) return;
+  const clearLocalSession = useCallback(() => {
+    setAuthToken(null);
+    setToken(null);
+    setUser(null);
+  }, []);
 
-    const interval = setInterval(() => {
-      if (isTokenExpired(token)) {
-        logout();
+  const syncSession = useCallback(async () => {
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_AUTH_SERVICE_BACKEND}/api/v1/users/session`,
+        { credentials: "include" },
+      );
+      if (!response.ok) {
+        clearLocalSession();
+        return false;
       }
-    }, 60000);
 
-    return () => clearInterval(interval);
-  }, [token, logout]);
+      const data = await response.json() as { token?: string };
+      if (!data.token) {
+        clearLocalSession();
+        return false;
+      }
+
+      login(data.token);
+      return true;
+    } catch (error) {
+      console.error("Error synchronizing Auth session:", error);
+      return false;
+    }
+  }, [clearLocalSession, login]);
+
+  const logout = useCallback(() => {
+    void fetch(
+      `${import.meta.env.VITE_AUTH_SERVICE_BACKEND}/api/v1/users/logout`,
+      { method: "POST", credentials: "include" },
+    ).catch((error) => console.error("Error closing Auth session:", error));
+    clearLocalSession();
+    navigate("/login");
+  }, [clearLocalSession, navigate]);
+
+  useEffect(() => {
+    localStorage.removeItem("token");
+    void syncSession().finally(() => setIsLoading(false));
+  }, [syncSession]);
+
+  useEffect(() => {
+    const refresh = () => void syncSession();
+    const interval = window.setInterval(refresh, 5 * 60 * 1000);
+    window.addEventListener("focus", refresh);
+    return () => {
+      window.clearInterval(interval);
+      window.removeEventListener("focus", refresh);
+    };
+  }, [syncSession]);
 
   const value: AuthContextType = {
     token,

--- a/src/lib/authToken.ts
+++ b/src/lib/authToken.ts
@@ -1,0 +1,7 @@
+let currentToken: string | null = null;
+
+export const getAuthToken = (): string | null => currentToken;
+
+export const setAuthToken = (token: string | null): void => {
+  currentToken = token;
+};

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,18 +1,21 @@
 import axios from 'axios';
 import type { AxiosResponse, AxiosError } from 'axios';
+import { getAuthToken, setAuthToken } from './authToken';
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_APP_BACKEND,
 });
 export const authApi = axios.create({
   baseURL: import.meta.env.VITE_AUTH_SERVICE_BACKEND,
+  withCredentials: true,
 });
-const getToken = (): string | null => {
-  return localStorage.getItem('token');
-};
 
 const logout = (): void => {
-  localStorage.removeItem('token');
+  setAuthToken(null);
+  void fetch(
+    `${import.meta.env.VITE_AUTH_SERVICE_BACKEND}/api/v1/users/logout`,
+    { method: 'POST', credentials: 'include' },
+  ).catch((error) => console.error('Error closing Auth session:', error));
   window.location.href = '/login';
 };
 
@@ -22,7 +25,7 @@ const forbidden = (): void => {
 
 api.interceptors.request.use(
   (config) => {
-    const token = getToken();
+    const token = getAuthToken();
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -59,7 +62,7 @@ api.interceptors.response.use(
 
 authApi.interceptors.request.use(
   (config) => {
-    const token = getToken();
+    const token = getAuthToken();
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }

--- a/src/screens/Login.tsx
+++ b/src/screens/Login.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
 import axios from "axios";
 import {
@@ -23,7 +23,7 @@ import { isTurnstileEnabled } from "../config/turnstile";
 
 export const Login = () => {
   const navigate = useNavigate();
-  const { login } = useAuth();
+  const { login, token } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
@@ -36,6 +36,10 @@ export const Login = () => {
   const handleTurnstileTokenChange = useCallback((token: string) => {
     setTurnstileToken(token);
   }, []);
+
+  useEffect(() => {
+    if (token) navigate("/", { replace: true });
+  }, [navigate, token]);
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -60,6 +64,7 @@ export const Login = () => {
           password: password.trim(),
           ...(isTurnstileEnabled && { "cf-turnstile-response": turnstileToken }),
         },
+        { withCredentials: true },
       );
       const token = response.data.token;
       if (!token) {


### PR DESCRIPTION
## Summary
- exchange the Auth HttpOnly session cookie for a short-lived access token at startup
- keep access tokens in memory instead of localStorage
- refresh the session on focus and every five minutes
- send credentials during login, session refresh, and logout
- redirect an already authenticated user away from login

## Rollout
Deploy after the leia-auth session endpoints and the Designer backend JWT validation changes.

## Validation
- focused ESLint passes
- production build passes